### PR TITLE
Add keys to info.plist for Mechanic

### DIFF
--- a/WurstSchreiber.roboFontExt/info.plist
+++ b/WurstSchreiber.roboFontExt/info.plist
@@ -33,5 +33,9 @@
 	<real>1391695608.2098999</real>
 	<key>version</key>
 	<string>1.0</string>
+	<key>repository</key>
+	<string>asaumierdemers/WurstSchreiber</string>
+	<key>extensionPath</key>
+	<string>WurstSchreiber.roboFontExt</string>
 </dict>
 </plist>


### PR DESCRIPTION
I've added the keys necessary to make your RoboFont extension downloadable through the [Mechanic extension manager](https://github.com/jackjennings/Mechanic). Mechanic allows RoboFont users to download extensions that are publicly hosted on Github, and notifies users when an extension has a new version available.
